### PR TITLE
Refactor FlashCard and FlashCardControl components

### DIFF
--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -13,7 +13,7 @@ const props = defineProps<Props>()
 const showAnswer = defineModel<boolean>('showAnswer')
 
 const originalText = computed<string>(() => (props.target === 'en' ? props.tl : props.en))
-const translatedText = computed<string>(() => (props.target === 'en' ? props.en : props.tl))
+const translatedText = computed<string>(() => props[props.target])
 const bottomHalfStyle = computed<CSSProperties>(() => {
 	return showAnswer.value ? { transform: 'rotateX(0)' } : { transform: 'rotateX(-90deg)' }
 })

--- a/src/components/FlashCardControl.vue
+++ b/src/components/FlashCardControl.vue
@@ -2,8 +2,8 @@
 type Props = {
 	/** Tagalog text */
 	tl: string
-	/** Whether or not the answer is showing */
-	showAnswer: boolean
+	/** Whether user can play the text or not */
+	canPlay: boolean
 }
 const props = defineProps<Props>()
 
@@ -35,8 +35,8 @@ watch(isPlaying, () => {
 			:aria-label="playing ? 'Stop' : 'Play'"
 			type="button"
 			class="grid h-12 w-12 place-items-center rounded-full"
-			:class="{ 'text-blue-200': !showAnswer }"
-			:disabled="!showAnswer"
+			:class="{ 'text-blue-200': !canPlay }"
+			:disabled="!canPlay"
 			@click="playing ? stop() : speak()"
 		>
 			<Icon size="3rem" :name="isPlaying ? 'carbon:stop-outline' : 'carbon:play-outline'" />

--- a/src/pages/flash-cards.vue
+++ b/src/pages/flash-cards.vue
@@ -17,6 +17,10 @@ function toggleTarget(): void {
 	target.value = target.value === 'tl' ? 'en' : 'tl'
 }
 const currentTarget = computed<string>(() => (target.value === 'tl' ? 'Tagalog' : 'English'))
+
+const canPlay = computed<boolean>(() => { 
+	return target.value === 'tl' ? showAnswer.value : true
+})
 </script>
 
 <template>
@@ -25,6 +29,6 @@ const currentTarget = computed<string>(() => (target.value === 'tl' ? 'Tagalog' 
 			currentTarget
 		}}</button>
 		<FlashCard v-model:show-answer="showAnswer" :en="text.en" :tl="text.tl" :target="target" />
-		<FlashCardControl :tl="text.tl" :show-answer="showAnswer" @next="showNext" />
+		<FlashCardControl :tl="text.tl" :can-play="canPlay" @next="showNext" />
 	</div>
 </template>

--- a/src/pages/flash-cards.vue
+++ b/src/pages/flash-cards.vue
@@ -18,7 +18,7 @@ function toggleTarget(): void {
 }
 const currentTarget = computed<string>(() => (target.value === 'tl' ? 'Tagalog' : 'English'))
 
-const canPlay = computed<boolean>(() => { 
+const canPlay = computed<boolean>(() => {
 	return target.value === 'tl' ? showAnswer.value : true
 })
 </script>


### PR DESCRIPTION
This pull request refactors the FlashCard and FlashCardControl components. It updates the computed property `translatedText` in the FlashCard component to use the `props[props.target]` syntax instead of the previous ternary expression. It also updates the FlashCardControl component to use the prop `canPlay` instead of `showAnswer` to determine if the user can play the text.