### PR TITLE
Update eslint version to 8.56.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@vue/language-plugin-pug": "^1.8.27",
     "@vueuse/core": "^10.7.2",
     "@vueuse/nuxt": "^10.7.2",
-    "eslint": "^8.53.0",
+    "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-jsdoc": "^48.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ devDependencies:
     specifier: ^10.7.2
     version: 10.7.2(nuxt@3.10.0)(vue@3.4.19)
   eslint:
-    specifier: ^8.53.0
+    specifier: ^8.56.0
     version: 8.56.0
   eslint-config-prettier:
     specifier: ^9.0.0
@@ -957,7 +957,7 @@ packages:
       debug: 4.3.4
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.0
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -4729,7 +4729,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.0
+      ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3


### PR DESCRIPTION
This pull request updates the eslint version in the package.json and pnpm-lock.yaml files to version 8.56.0.