### PR TITLE
refactor: Add .ts extension to import statements

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,7 +42,7 @@ reviews:
         - Prefer the guard clause (early return) when the rest of the function can be executed through that return.
         - Use `Set` postfix for Set object variables.
         - Use `Map` postfix for Map object variables.
-        - Do not rely on Nuxt auto-import system. Import files explicitly.
+        - Do not rely on Nuxt auto-import system. Import files explicitly except for Vue, Nuxt and Pinia APIs.
         - Put .ts extension when importing TypeScript file
         - Prefer `shallowRef` over `ref` unless deep watching is needed.
     - path: "**/*.vue"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,13 +5,13 @@
 	"[html]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"[typescript]": {
-		"editor.defaultFormatter": "biomejs.biome"
-	},
 	"[json]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
 	"[jsonc]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[typescript]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
 	"[vue]": {
@@ -69,14 +69,16 @@
 	"files.autoSave": "afterDelay",
 	"files.autoSaveDelay": 1000,
 	"files.autoSaveWhenNoErrors": true,
-	"github.copilot.chat.experimental.codeGeneration.instructions": [
+	"github.copilot.chat.codeGeneration.instructions": [
 		{
 			"file": "coding-guidelines.md"
 		}
 	],
+	"javascript.preferences.importModuleSpecifierEnding": "js",
 	"tailwindCSS.emmetCompletions": true,
-	"typescript.preferGoToSourceDefinition": true,
+	"typescript.preferences.importModuleSpecifierEnding": "js",
 	"typescript.preferences.preferTypeOnlyAutoImports": true,
+	"typescript.preferGoToSourceDefinition": true,
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"vue.inlayHints.inlineHandlerLeading": true,
 	"vue.inlayHints.missingProps": true,

--- a/app/components/NavigationMenu.vue
+++ b/app/components/NavigationMenu.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useAuthStore } from '~/stores/auth'
+import { useAuthStore } from '~/stores/auth.ts'
 
 const showMenu = shallowRef(false)
 const { signOut } = useAuthStore()

--- a/app/components/TextList.vue
+++ b/app/components/TextList.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import TextListItem from '~/components/TextListItem.vue'
-import { useTextSearch } from '~/composables/useTextSearch'
+import { useTextSearch } from '~/composables/useTextSearch.ts'
 
 const props = defineProps<{
 	/** Text that is used as a search word */

--- a/app/components/TextListItem.vue
+++ b/app/components/TextListItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Text } from '~/database.types'
+import type { Text } from '~/database.types.ts'
 
 type FetchedText = Pick<Text, 'id' | 'en' | 'tl'>
 

--- a/app/composables/useSentenceQuiz.spec.ts
+++ b/app/composables/useSentenceQuiz.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { useSentenceQuiz } from './useSentenceQuiz.ts'
 
 describe('useSentenceQuiz', () => {

--- a/app/composables/useSentenceQuiz.spec.ts
+++ b/app/composables/useSentenceQuiz.spec.ts
@@ -1,4 +1,4 @@
-import { useSentenceQuiz } from './useSentenceQuiz'
+import { useSentenceQuiz } from './useSentenceQuiz.ts'
 
 describe('useSentenceQuiz', () => {
 	const text = {

--- a/app/composables/useTextSearch.ts
+++ b/app/composables/useTextSearch.ts
@@ -1,5 +1,5 @@
-import type { Database } from '~/database-generated.types'
-import type { Text } from '~/database.types'
+import type { Database } from '~/database-generated.types.ts'
+import type { Text } from '~/database.types.ts'
 
 type FetchedText = Pick<Text, 'id' | 'en' | 'tl'>
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import NavigationMenu from '~/components/NavigationMenu.vue'
-import { useAuthStore } from '~/stores/auth'
+import { useAuthStore } from '~/stores/auth.ts'
 
 const { loggedIn } = storeToRefs(useAuthStore())
 </script>

--- a/app/pages/confirm.vue
+++ b/app/pages/confirm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useAuthStore } from '~/stores/auth'
+import { useAuthStore } from '~/stores/auth.ts'
 
 const { loggedIn } = storeToRefs(useAuthStore())
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import LevelSelectorModal from '~/components/LevelSelectorModal.vue'
-import { useAuthStore } from '~/stores/auth'
+import { useAuthStore } from '~/stores/auth.ts'
 
 const authStore = useAuthStore()
 const { userName } = storeToRefs(authStore)

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useAuthStore } from '~/stores/auth'
+import { useAuthStore } from '~/stores/auth.ts'
 
 const authStore = useAuthStore()
 const { loggedIn } = storeToRefs(authStore)

--- a/app/pages/match-words.vue
+++ b/app/pages/match-words.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { integer, maxValue, minValue, object, pipe, string, transform } from 'valibot'
 import WordBlock from '~/components/WordBlock.vue'
-import { shuffle } from '~/utils/shuffle'
+import { shuffle } from '~/utils/shuffle.ts'
 
 const queryParamsSchema = object({
 	/** The level of quiz */

--- a/app/pages/quiz.vue
+++ b/app/pages/quiz.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { integer, maxValue, minValue, object, pipe, string, transform } from 'valibot'
 import MemoryLevelMeter from '~/components/MemoryLevelMeter.vue'
-import { useQueryParamsWithSchema } from '~/composables/useQueryParamsWithSchema'
-import { useTextQuiz } from '~/composables/useTextQuiz'
+import { useQueryParamsWithSchema } from '~/composables/useQueryParamsWithSchema.ts'
+import { useTextQuiz } from '~/composables/useTextQuiz.ts'
 
 const queryParamsSchema = object({
 	/** The level of quiz */

--- a/app/utils/shuffle.spec.ts
+++ b/app/utils/shuffle.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { shuffle } from './shuffle.ts'
 
 describe('shuffle', () => {

--- a/app/utils/shuffle.spec.ts
+++ b/app/utils/shuffle.spec.ts
@@ -1,4 +1,4 @@
-import { shuffle } from './shuffle'
+import { shuffle } from './shuffle.ts'
 
 describe('shuffle', () => {
 	it('has the same length as the input', () => {

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,17 @@
 				"useFlatMap": "error"
 			},
 			"correctness": {
+				"useImportExtensions": {
+					"level": "error",
+					"options": {
+						"suggestedExtensions": {
+							"ts": {
+								"module": "ts",
+								"component": "vue"
+							}
+						}
+					}
+				},
 				"noUnusedImports": "warn",
 				"noUnusedVariables": "warn"
 			},

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,8 +54,10 @@ export default defineNuxtConfig({
 	typescript: {
 		tsConfig: {
 			compilerOptions: {
+				allowImportingTsExtensions: true,
 				allowUnreachableCode: false,
 				exactOptionalPropertyTypes: true,
+				erasableSyntaxOnly: true,
 				forceConsistentCasingInFileNames: true,
 				noErrorTruncation: true,
 				noFallthroughCasesInSwitch: true,

--- a/shared/utils/clamp.spec.ts
+++ b/shared/utils/clamp.spec.ts
@@ -1,4 +1,4 @@
-import { clamp } from './clamp'
+import { clamp } from './clamp.ts'
 
 describe('clamp', () => {
 	it('clamps a value between a minimum and maximum value', () => {

--- a/shared/utils/clamp.spec.ts
+++ b/shared/utils/clamp.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { clamp } from './clamp.ts'
 
 describe('clamp', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated all import statements to explicitly include the `.ts` file extension for TypeScript files and `.vue` for components, ensuring consistency across the codebase.
  - Refined VSCode settings and import-related instructions to support explicit extension usage.

- **Chores**
  - Added a linting rule to enforce explicit file extensions in imports.
  - Adjusted VSCode and TypeScript configuration settings to support and require explicit import extensions.
  - Modified project guidelines to allow Nuxt auto-imports for Vue, Nuxt, and Pinia APIs only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->