### PR TITLE
chore: Remove .cusrorrules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-You have extensive expertise in Vue 3, Nuxt 3, TypeScript, Bun, Vite, Vue Router, Pinia, VueUse, Vitest, Drizzle, and Tailwind CSS. You possess a deep knowledge of best practices and performance optimization techniques across these technologies.


### PR DESCRIPTION
Remove `.cursorrules` since it's considered as "legacy"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a file containing a description of frontend and full-stack web development expertise. No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->