### PR TITLE
chore: Use interface over type

### DIFF
--- a/app/composables/useSentenceQuiz.ts
+++ b/app/composables/useSentenceQuiz.ts
@@ -1,13 +1,13 @@
 import type { Text } from '~/database.types'
 
-type WordInfo = {
+interface WordInfo {
 	id: number
 	word: string
 }
 
 type QuizStatus = 'selecting' | 'correct' | 'incorrect'
 
-type ReturnType = {
+interface ReturnType {
 	english: string
 	words: ComputedRef<WordInfo[]>
 	selectedWords: ComputedRef<WordInfo[]>

--- a/app/composables/useTextSearch.ts
+++ b/app/composables/useTextSearch.ts
@@ -3,7 +3,7 @@ import type { Database } from '~/database-generated.types.ts'
 
 type FetchedText = Pick<Text, 'id' | 'en' | 'tl'>
 
-type ReturnType = {
+interface ReturnType {
 	loading: Ref<boolean>
 	texts: Ref<FetchedText[]>
 	searchWords: Ref<string[]>

--- a/app/database-generated.types.ts
+++ b/app/database-generated.types.ts
@@ -1,6 +1,6 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
-export type Database = {
+export interface Database {
 	graphql_public: {
 		Tables: {
 			[_ in never]: never

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -32,7 +32,7 @@ async function handleLevelSelect(level: number): Promise<void> {
 	})
 }
 
-type MenuItem = {
+interface MenuItem {
 	name: string
 	icon: string
 	description: string

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,9 @@ export default withNuxt([])
 			},
 		},
 		rules: {
+			// See: https://ts.dev/style/#interfaces-vs-type-aliases
+			// See: https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections
+			'@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
 			'@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
 			'@typescript-eslint/strict-boolean-expressions': [
 				'error',

--- a/server/utils/getNextMemoryLevel.ts
+++ b/server/utils/getNextMemoryLevel.ts
@@ -18,14 +18,14 @@ const MEMORY_LEVEL_TO_NEXT_DUE_DATE = {
 	8: 230, // ~8 months
 } as const
 
-type GetNextMemoryLevelParams = {
+interface GetNextMemoryLevelParams {
 	/** The current memory level of the text */
 	currentMemoryLevel: number
 	/** Whether the user remembered the text or not */
 	remembered: boolean
 }
 
-type ReturnType = {
+interface ReturnType {
 	/** The next memory level */
 	nextMemoryLevel: keyof typeof MEMORY_LEVEL_TO_NEXT_DUE_DATE
 	/** The interval in hours */


### PR DESCRIPTION
According to the following links, using interface is a better option than type when defining object types

- https://ts.dev/style/#interfaces-vs-type-aliases
- https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections