### PR TITLE
refactor: Use plain CSS instead of Tailwind for WordBlock

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -65,6 +65,9 @@ reviews:
         - Prefer `v-show` over `v-if` for conditional visibility.
         - Specify `type` attribute for `<button>` elements.
         - Pass an object to `<NuxtLink :to>` for better type safety. For example, `<NuxtLink :to="{ name: 'about' }">`.
-        - Use TailwindCSS for styling.
+        - Use modern CSS features as much as possible.
+        - Use logical properties. For example, Use `inline-size` over `width`.
+        - Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform`.
+        - Use `oklch` for colors.
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -65,9 +65,9 @@ reviews:
         - Prefer `v-show` over `v-if` for conditional visibility.
         - Specify `type` attribute for `<button>` elements.
         - Pass an object to `<NuxtLink :to>` for better type safety. For example, `<NuxtLink :to="{ name: 'about' }">`.
-        - Use modern CSS features as much as possible.
+        - Use modern CSS features as much as possible, assuming users always use the latest browser versions.
         - Use logical properties. For example, Use `inline-size` over `width`.
-        - Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform`.
-        - Use `oklch` for colors.
+        - Use OKLCH for colors.
+        - Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform` shorthand.
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,8 +66,8 @@ reviews:
         - Specify `type` attribute for `<button>` elements.
         - Pass an object to `<NuxtLink :to>` for better type safety. For example, `<NuxtLink :to="{ name: 'about' }">`.
         - Use modern CSS features as much as possible, assuming users always use the latest browser versions.
-        - Use logical properties. For example, Use `inline-size` over `width`.
-        - Use OKLCH for colors.
-        - Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform` shorthand.
+        - Use logical properties—for example, `inline-size` instead of `width`.
+        - Use OKLCH for colors—no need for RGB / HSL fallback.
+        - Prefer individual transform properties (`translate`, `rotate`, `scale`) over the `transform` shorthand.
 chat:
   auto_reply: true

--- a/.cursor/rules/vue.mdc
+++ b/.cursor/rules/vue.mdc
@@ -34,5 +34,5 @@ alwaysApply: false
 
 - Use modern CSS features as much as possible.
 - Use logical properties. For example, Use `inline-size` over `width`.
-- Use oklch when defining colors.
+- Use OKLCH when defining colors.
 - Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform`.

--- a/.cursor/rules/vue.mdc
+++ b/.cursor/rules/vue.mdc
@@ -33,6 +33,6 @@ alwaysApply: false
 # CSS
 
 - Use modern CSS features as much as possible, assuming users always use the latest browser versions.
-- Use logical properties. For example, Use `inline-size` over `width`.
-- Use OKLCH when defining colors.
-- Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform` shorthand.
+- Use logical properties—for example, `inline-size` instead of `width`.
+- Use OKLCH for colors—no need for RGB / HSL fallback.
+- Prefer individual transform properties (`translate`, `rotate`, `scale`) over the `transform` shorthand.

--- a/.cursor/rules/vue.mdc
+++ b/.cursor/rules/vue.mdc
@@ -26,11 +26,13 @@ alwaysApply: false
 - Pass an object to `navigateTo` for better type safety. For example, `navigateTo({ name: 'about' })` instead of `navigateTo('/about')`.
 - Pass an object to `<NuxtLink :to>` for better type safety. For example, `<NuxtLink :to="{ name: 'about' }">`.
 
-# Tailwind CSS
-
-- Use colors from the `colors` object in `app/tailwind.config.ts`.
-
 # HTML
 
 - Specify `type` attribute for `<button>` elements.
 
+# CSS
+
+- Use modern CSS features as much as possible.
+- Use logical properties. For example, Use `inline-size` over `width`.
+- Use oklch when defining colors.
+- Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform`.

--- a/.cursor/rules/vue.mdc
+++ b/.cursor/rules/vue.mdc
@@ -32,7 +32,7 @@ alwaysApply: false
 
 # CSS
 
-- Use modern CSS features as much as possible.
+- Use modern CSS features as much as possible, assuming users always use the latest browser versions.
 - Use logical properties. For example, Use `inline-size` over `width`.
 - Use OKLCH when defining colors.
-- Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform`.
+- Use `translate`, `rotate`, `scale` ((Individual transform properties)) individually over `transform` shorthand.

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,7 +1,3 @@
-a:hover {
-	cursor: pointer;
-}
-
 button:hover {
 	cursor: pointer;
 }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,0 +1,7 @@
+a:hover {
+	cursor: pointer;
+}
+
+button:hover {
+	cursor: pointer;
+}

--- a/app/components/WordBlock.vue
+++ b/app/components/WordBlock.vue
@@ -18,25 +18,87 @@ defineProps<{
 <template>
 	<button
 		type="button"
-		class="w-full transform cursor-pointer rounded-lg border-2 p-4 text-center transition-all duration-300"
+		class="word-button"
 		:class="{
-			'border-gray-200 bg-white hover:scale-105 hover:border-blue-500 hover:shadow-md':
-				!matched && !selected,
-			'scale-105 animate-pulse border-blue-500 bg-blue-50 shadow-md': selected,
-			'scale-100 border-green-500 bg-green-50 shadow-sm': matched,
-			'cursor-not-allowed opacity-50': disabled,
+			default: !matched && !selected,
+			selected: selected,
+			matched: matched,
+			disabled: disabled,
 		}"
 		:disabled="disabled"
 	>
 		<span
-			class="font-medium"
+			class="text"
 			:class="{
-				'text-gray-700': !matched && !selected,
-				'text-blue-700': selected,
-				'text-green-700': matched,
+				default: !matched && !selected,
+				selected: selected,
+				matched: matched,
 			}"
 		>
 			{{ text }}
 		</span>
 	</button>
 </template>
+
+<style scoped>
+.word-button {
+	inline-size: 100%;
+	border-radius: 0.5rem;
+	border-width: 2px;
+	padding: 1rem;
+	text-align: center;
+	transition: all 0.3s;
+	scale: 1;
+	translate: 0 0;
+	rotate: 0deg;
+	background: oklch(1 0 0);
+	border-color: oklch(0.92 0 0);
+	box-shadow: none;
+
+	&.default:hover {
+		scale: 1.05;
+		border-color: oklch(0.68 0.19 264);
+		box-shadow: 0 4px 12px oklch(0.68 0.19 264 / 0.15);
+	}
+	&.selected {
+		scale: 1.05;
+		animation: word-button-pulse 1s infinite;
+		border-color: oklch(0.68 0.19 264);
+		background: oklch(0.97 0.03 264);
+		box-shadow: 0 4px 12px oklch(0.68 0.19 264 / 0.15);
+	}
+	&.matched {
+		scale: 1;
+		border-color: oklch(0.78 0.17 142);
+		background: oklch(0.98 0.03 142);
+		box-shadow: 0 2px 6px oklch(0.78 0.17 142 / 0.1);
+	}
+	&.disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+}
+@keyframes word-button-pulse {
+	0% {
+		box-shadow: 0 0 0 0 oklch(0.68 0.19 264 / 0.4);
+	}
+	70% {
+		box-shadow: 0 0 0 10px oklch(0.68 0.19 264 / 0);
+	}
+	100% {
+		box-shadow: 0 0 0 0 oklch(0.68 0.19 264 / 0);
+	}
+}
+.text {
+	font-weight: 500;
+	&.default {
+		color: oklch(0.36 0 0);
+	}
+	&.selected {
+		color: oklch(0.41 0.13 264);
+	}
+	&.matched {
+		color: oklch(0.44 0.13 142);
+	}
+}
+</style>

--- a/app/composables/useMatchWords.ts
+++ b/app/composables/useMatchWords.ts
@@ -35,6 +35,7 @@ interface UseMatchWordsReturn {
  * @param words - The list of words to be matched.
  */
 export function useMatchWords(words: Ref<Word[]>): UseMatchWordsReturn {
+	/** Set of word IDs that a user correctly matched */
 	const matchedWordIdSet = shallowRef<Set<string>>(new Set())
 	const isCompleted = computed<boolean>(
 		() => words.value.length > 0 && matchedWordIdSet.value.size === words.value.length,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
 			link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }],
 		},
 	},
-	css: [],
+	css: ['~/assets/css/main.css'],
 	runtimeConfig: {
 		public: {
 			baseUrl: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refactored component styling to use semantic CSS classes and modern CSS features, including logical properties and the OKLCH color format.
  * Replaced inline utility classes with scoped, maintainable CSS in components.
  * Updated hover effects for buttons and links to display a pointer cursor, improving interactivity cues.

* **Documentation**
  * Updated internal styling guidelines to recommend modern CSS practices and deprecate TailwindCSS-specific instructions.

* **Chores**
  * Included a global CSS file in the application configuration for consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->